### PR TITLE
Move to self-hosted backend

### DIFF
--- a/.github/workflows/tf-preview.yaml
+++ b/.github/workflows/tf-preview.yaml
@@ -1,5 +1,4 @@
-name: Speculative Run
-
+name: Terraform
 on:
   workflow_dispatch:
     inputs:
@@ -7,23 +6,25 @@ on:
         description: "URL from which to download the workspace"
         required: true
         type: string
-
 jobs:
   plan:
-    name: Plan
+    name: Speculative Plan
     runs-on: ubuntu-22.04
     env:
+      # renovate: datasource=github-releases depName=hashicorp/terraform
+      TERRAFORM_VERSION: "1.6.6"
       TF_HTTP_PASSWORD: ${{ github.token }}
       TF_IN_AUTOMATION: "true"
-      TF_CLI_ARGS: "-input=false"
-      TF_LOG: "debug"
+      TF_CLI_ARGS: -input=false
+
+      # environment variables for providers
       NETBOX_API_TOKEN: ${{ secrets.NETBOX_API_TOKEN }}
     steps:
       - name: Download Workspace
         run: |
-          curl ${{ inputs.workspace_transfer_url }} --fail --silent | tar -xzf -
+          curl ${{ inputs.workspace_transfer_url }} --user github_pat:${TF_HTTP_PASSWORD} --fail --silent | tar -xzf -
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.6.6"
+          terraform_version: ${TERRAFORM_VERSION}
       - run: terraform init
       - run: terraform plan

--- a/.github/workflows/tf-run.yaml
+++ b/.github/workflows/tf-run.yaml
@@ -1,10 +1,8 @@
 name: Terraform
-
 on:
   push:
     branches: [main]
   pull_request:
-
 jobs:
   run:
     name: Run
@@ -17,28 +15,27 @@ jobs:
       pull-requests: write
       checks: write
     env:
+      # renovate: datasource=github-releases depName=hashicorp/terraform
+      TERRAFORM_VERSION: "1.6.6"
       TF_HTTP_PASSWORD: ${{ github.token }}
       TF_IN_AUTOMATION: "true"
       TF_CLI_ARGS: "-input=false"
+
+      # environment variables for providers
       NETBOX_API_TOKEN: ${{ secrets.NETBOX_API_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.6.6"
-
+          terraform_version: ${TERRAFORM_VERSION}
       - run: terraform init
-
       - run: terraform plan -out=tfplan
       - name: terraform apply
-        env:
-          TF_LOG: "debug"
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         run: |
           set -o pipefail
           terraform apply tfplan | tee apply.log
-        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       - name: Backup state
         if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         env:
@@ -59,14 +56,12 @@ jobs:
             jq -r '.Contents | map(.Key) | sort | reverse | .[5:] | .[]' \
           )
           for file in ${DELETE_FILES}; do aws s3 rm s3://${S3_BUCKET}/$file; done
-
       - run: terraform show -json tfplan > tfplan.json
         env:
           TF_CLI_ARGS: ""
       - run: terraform show -no-color tfplan > summary.txt
         env:
           TF_CLI_ARGS: ""
-
       - name: Create status check with details
         uses: actions/github-script@v7
         with:
@@ -124,7 +119,6 @@ jobs:
                 summary,
               },
             });
-
       - name: Show plan on PR
         uses: actions/github-script@v7
         if: ${{ github.event_name == 'pull_request' }}
@@ -176,7 +170,7 @@ jobs:
 
             const codefence = "```"
             const body = `
-            🏗️ Terraform Plan
+            #### :building_construction: Terraform Plan
             ${codefence}
             ${plan.trim("\n")}
             ${codefence}`

--- a/backend.tf
+++ b/backend.tf
@@ -1,11 +1,8 @@
 terraform {
   backend "http" {
-    # see https://tfstate.dev/ for instructions
-    address        = "https://api.tfstate.dev/github/v1"
-    lock_address   = "https://api.tfstate.dev/github/v1/lock"
-    unlock_address = "https://api.tfstate.dev/github/v1/lock"
-    lock_method    = "PUT"
-    unlock_method  = "DELETE"
-    username       = "ffddorf/terraform-gre-sites@dev"
+    address        = "https://ffddorf-terraform-backend.fly.dev/state/terraform-gre-sites/default"
+    lock_address   = "https://ffddorf-terraform-backend.fly.dev/state/terraform-gre-sites/default"
+    unlock_address = "https://ffddorf-terraform-backend.fly.dev/state/terraform-gre-sites/default"
+    username       = "github_pat"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "regexManagers:githubActionsVersions"
   ]
 }


### PR DESCRIPTION
We're now hosting an instance of https://github.com/ffddorf/terraform-backend which can be used to manage the state and helps with speculative runs.